### PR TITLE
Fix an exception when change icon

### DIFF
--- a/SuperDuperMacro_Core.lua
+++ b/SuperDuperMacro_Core.lua
@@ -411,7 +411,9 @@ function sdm_UpgradeMacro(index) -- Upgrades the given standard macro to a Super
 	local body = GetMacroBody(index)
 	EditMacro(index, nil, nil, "#sdm"..sdm_numToChars(sdm_GetEmptySlot()).."\n#placeholder") -- let SDM know that this is the macro to edit
 	local _, texture = GetMacroInfo(index) -- This must be done AFTER the macro body is edited, or the question mark could show up as something else.
-	texture = texture:sub(17) -- remove the "INTERFACE\\ICONS\\"
+	if type(texture) ~= "number" then
+		texture = texture:sub(17) -- remove the "INTERFACE\\ICONS\\"
+	end
 	local newMacro = sdm_CreateNew("b", name, character)
 	newMacro.icon = texture
 	sdm_Edit(newMacro, body)

--- a/SuperDuperMacro_Frames.lua
+++ b/SuperDuperMacro_Frames.lua
@@ -13,10 +13,12 @@ f:SetPoint("TOPLEFT", 0, -104)
 sdm_MakeDraggable(f)
 f:SetScript("OnShow", function(self)
 	--PlaySound "igCharacterInfoOpen"
+	PlaySound(839)
 	sdm_UpdateList()
 end)
 f:SetScript("OnHide", function(self)
 	--PlaySound "igCharacterInfoClose"
+	PlaySound(840)
 	sdm_currentlyPlacing=nil
 	sdm_StopMove()
 	self:ClearAllPoints()

--- a/SuperDuperMacro_Interface.lua
+++ b/SuperDuperMacro_Interface.lua
@@ -427,10 +427,16 @@ function sdm_UpdateList()
 			end
 			sdm_SetTooltip(listItem, "Alt-click for folder options and instructions")
 		else
-			if mTab.icon:upper() == sdm_defaultIcon and mTab.type=="b" and (sdm_UsedByThisChar(mTab)) then
-				_,texture = GetMacroInfo(sdm_GetMacroIndex(mTab.ID))
-			else
-				texture = "INTERFACE\\ICONS\\"..mTab.icon
+			-- if mTab.icon:upper() == sdm_defaultIcon and mTab.type=="b" and (sdm_UsedByThisChar(mTab)) then
+            if type(mTab.icon) == "number" then
+                texture = mTab.icon
+            else
+                if mTab.icon:upper() == sdm_defaultIcon and mTab.type=="b" and (sdm_UsedByThisChar(mTab)) then
+                    _,texture = GetMacroInfo(sdm_GetMacroIndex(mTab.ID))
+                else
+                    texture = "INTERFACE\\ICONS\\"..mTab.icon
+                end
+			-- texture = "INTERFACE\\ICONS\\"..mTab.icon
 			end
 			if texture then
 				listItem.icon:SetTexture(texture)
@@ -633,7 +639,8 @@ function sdm_OnShow_changeIconFrame(f)
 	MacroPopupFrame:SetPoint("TOP", f, "BOTTOM", 0,15)
 	MacroPopupFrame:Show()
 	_,_,_,_,f.fontstring = MacroPopupFrame:GetRegions()
-	f.fontstring:SetText("        Different name on button:")
+	-- f.fontstring:SetText("        Different name on button:")
+    -- I don't know what is it now, and I try print all returns in MacroPopupFrame:GetRegions() but none of them has 'SetText' method.
 	MacroPopupOkayButton:Hide()
 	MacroPopupCancelButton:Hide()
 	MacroPopupFrame_sdmOkayButton:Show()
@@ -666,7 +673,7 @@ function sdm_OnHide_changeIconFrame(f)
 	for _,point in ipairs(f.prevpoints) do
 		MacroPopupFrame:SetPoint(point[1], point[2], point[3], point[4], point[5])
 	end
-	f.fontstring:SetText(MACRO_POPUP_TEXT)
+	-- f.fontstring:SetText(MACRO_POPUP_TEXT)
 	f.fontstring:Show()
 	MacroPopupEditBox:Show()
 	MacroPopupOkayButton:Show()
@@ -678,7 +685,7 @@ function sdm_OnHide_changeIconFrame(f)
 end
 
 function sdm_GetSelectedIcon()
-	return GetSpellorMacroIconInfo(MacroPopupFrame.selectedIcon)
+	return GetSpellorMacroIconInfo(MacroPopupFrame.selectedIcon) -- This will now return a number
 end
 
 function sdm_ChangeIconOkayed()

--- a/SuperDuperMacro_Interface.lua
+++ b/SuperDuperMacro_Interface.lua
@@ -428,14 +428,14 @@ function sdm_UpdateList()
 			sdm_SetTooltip(listItem, "Alt-click for folder options and instructions")
 		else
 			-- if mTab.icon:upper() == sdm_defaultIcon and mTab.type=="b" and (sdm_UsedByThisChar(mTab)) then
-            if type(mTab.icon) == "number" then
-                texture = mTab.icon
-            else
-                if mTab.icon:upper() == sdm_defaultIcon and mTab.type=="b" and (sdm_UsedByThisChar(mTab)) then
-                    _,texture = GetMacroInfo(sdm_GetMacroIndex(mTab.ID))
-                else
-                    texture = "INTERFACE\\ICONS\\"..mTab.icon
-                end
+			if type(mTab.icon) == "number" then
+				texture = mTab.icon
+			else
+				if mTab.icon:upper() == sdm_defaultIcon and mTab.type=="b" and (sdm_UsedByThisChar(mTab)) then
+					_,texture = GetMacroInfo(sdm_GetMacroIndex(mTab.ID))
+				else
+					texture = "INTERFACE\\ICONS\\"..mTab.icon
+				end
 			-- texture = "INTERFACE\\ICONS\\"..mTab.icon
 			end
 			if texture then
@@ -640,7 +640,7 @@ function sdm_OnShow_changeIconFrame(f)
 	MacroPopupFrame:Show()
 	_,_,_,_,f.fontstring = MacroPopupFrame:GetRegions()
 	-- f.fontstring:SetText("        Different name on button:")
-    -- I don't know what is it now, and I try print all returns in MacroPopupFrame:GetRegions() but none of them has 'SetText' method.
+	-- I don't know what is it now, and I try print all returns in MacroPopupFrame:GetRegions() but none of them has 'SetText' method.
 	MacroPopupOkayButton:Hide()
 	MacroPopupCancelButton:Hide()
 	MacroPopupFrame_sdmOkayButton:Show()


### PR DESCRIPTION
`sdm_GetSelectedIcon()` now return a number, so `mTab.icon:upper()` will make an exception.
I checked the type of `mTab.icon`, and It works fine now.